### PR TITLE
ミニマップ表示範囲の修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -440,13 +440,16 @@ function updateMinimap(nodes) {
     exit => exit.remove()
   );
 
+  // 実際に見えている領域の高さを求める
+  const visibleH = Math.min(chartContainer.clientHeight, chartContainer.scrollHeight);
+
   let vp = minimap.selectAll("rect.viewport").data([0]);
   vp = vp.join("rect")
     .attr("class", "viewport")
     .attr("x", 0)
     .attr("width", minimapWidth)
     .attr("y", chartContainer.scrollTop * scaleY)
-    .attr("height", chartContainer.clientHeight * scaleY);
+    .attr("height", visibleH * scaleY);
 
   // ビューポート矩形をドラッグ可能にし、スクロール位置に反映
   vp.call(
@@ -464,9 +467,10 @@ function updateMinimap(nodes) {
 function updateViewportRect() {
   if (mode !== "name") return;
   const scaleY = minimapHeight / height;
+  const visibleH = Math.min(chartContainer.clientHeight, chartContainer.scrollHeight);
   minimap.select("rect.viewport")
     .attr("y", chartContainer.scrollTop * scaleY)
-    .attr("height", chartContainer.clientHeight * scaleY);
+    .attr("height", visibleH * scaleY);
 }
 
 chartContainer.addEventListener("scroll", updateViewportRect);


### PR DESCRIPTION
## 概要
- ミニマップのビューポート高さが実際の表示領域と合わない問題を修正
- `updateMinimap` と `updateViewportRect` で可視領域を計算して反映

## テスト
- `npm test` を実行しましたが、`package.json` が存在せず失敗しました

------
https://chatgpt.com/codex/tasks/task_e_688b23cfe0408321800b677550d89d3a